### PR TITLE
Add init param to wz-step. Execute whats inside init on the $scope.$pare...

### DIFF
--- a/src/step.js
+++ b/src/step.js
@@ -4,7 +4,8 @@ angular.module('mgo-angular-wizard').directive('wzStep', function() {
         replace: true,
         transclude: true,
         scope: {
-            title: '@'
+            title: '@',
+            init: '@'
         },
         require: '^wizard',
         templateUrl: 'step.html',

--- a/src/wizard.js
+++ b/src/wizard.js
@@ -39,12 +39,17 @@ angular.module('mgo-angular-wizard').directive('wizard', function() {
                     });
                 }
             }, true);
-            
+
             this.addStep = function(step) {
                 $scope.steps.push(step);
                 if ($scope.steps.length === 1) {
                     $scope.goTo($scope.steps[0]);
                 }
+
+                if (typeof step.init !== 'undefined' && step.init){
+                    eval('$scope.$parent.'+step.init)
+                }
+
             };
             
             $scope.goTo = function(step) {


### PR DESCRIPTION
...nt via eval to call external method when a step is added to the wizard.

Example: wz-step(title="Client" init='myInitStep()')

I needed to set completed = true on all steps so I could reuse the wizard for create and update functionality.

JS is not my primary language so maybe there is a better way to handle this than via eval. 
