### PR TITLE
try fix #46 

### DIFF
--- a/src/step.js
+++ b/src/step.js
@@ -4,6 +4,7 @@ angular.module('mgo-angular-wizard').directive('wzStep', function() {
         replace: true,
         transclude: true,
         scope: {
+            displayTitle: '@',
             wzTitle: '@',
             title: '@'
         },
@@ -13,7 +14,14 @@ angular.module('mgo-angular-wizard').directive('wzStep', function() {
         },
         link: function($scope, $element, $attrs, wizard) {
             $scope.title = $scope.title || $scope.wzTitle;
+            $scope.displayTitle = $scope.displayTitle || $scope.title;
             wizard.addStep($scope);
-        }
+        },
+        controller: ["$scope", "$element", function ($scope, $element) {
+            $scope.Forms = [];
+            this.addForm = function (form) {
+                $scope.Forms.push(form);
+            };
+        }]
     };
 });

--- a/src/wizard.html
+++ b/src/wizard.html
@@ -2,7 +2,7 @@
     <div class="steps" ng-transclude></div>
     <ul class="steps-indicator steps-{{steps.length}}" ng-if="!hideIndicators">
       <li ng-class="{default: !step.completed && !step.selected, current: step.selected && !step.completed, done: step.completed && !step.selected, editing: step.selected && step.completed}" ng-repeat="step in steps">
-        <a ng-click="goTo(step)">{{step.title || step.wzTitle}}</a>
+          <a ng-click="!step.completed || goTo(step)">{{step.displayTitle || step.title || step.wzTitle}}</a>
       </li>
     </ul>
 </div>

--- a/src/wizard.js
+++ b/src/wizard.js
@@ -50,6 +50,8 @@ angular.module('mgo-angular-wizard').directive('wizard', function() {
             };
 
             $scope.goTo = function(step) {
+                if (!isSelectedStepValid()) return;
+
                 unselectAll();
                 $scope.selectedStep = step;
                 if (!_.isUndefined($scope.currentStep)) {
@@ -70,7 +72,22 @@ angular.module('mgo-angular-wizard').directive('wizard', function() {
                 $scope.selectedStep = null;
             }
 
+            function isSelectedStepValid() {
+                if (!$scope.selectedStep) return true;
+
+                var wzForms = $scope.selectedStep.Forms;
+                if (!wzForms) return true;
+
+                for (var i = 0; i < wzForms.length; i++) {
+                    if (wzForms[i] && wzForms[i].$invalid && wzForms[i].$dirty) return false;
+                }
+
+                return true;
+            };
+
             this.next = function(draft) {
+                if (!isSelectedStepValid()) return;
+
                 var index = _.indexOf($scope.steps , $scope.selectedStep);
                 if (!draft) {
                     $scope.selectedStep.completed = true;

--- a/src/wizard.js
+++ b/src/wizard.js
@@ -51,7 +51,8 @@ angular.module('mgo-angular-wizard').directive('wizard', function() {
 
             $scope.goTo = function(step) {
                 if (!isSelectedStepValid()) return;
-
+                
+                setSelectedStepSubmitted(false);
                 unselectAll();
                 $scope.selectedStep = step;
                 if (!_.isUndefined($scope.currentStep)) {
@@ -78,11 +79,18 @@ angular.module('mgo-angular-wizard').directive('wizard', function() {
                 var wzForms = $scope.selectedStep.Forms;
                 if (!wzForms) return true;
 
+                setSelectedStepSubmitted(true);
+
                 for (var i = 0; i < wzForms.length; i++) {
-                    if (wzForms[i] && wzForms[i].$invalid && wzForms[i].$dirty) return false;
+                    if (wzForms[i] && wzForms[i].$invalid) return false;
                 }
 
                 return true;
+            };
+
+            function setSelectedStepSubmitted(submitted) {
+                if (!$scope.selectedStep || !$scope.selectedStep.Forms) return;
+                angular.forEach($scope.selectedStep.Forms, function (form) { form.submitted = submitted; });
             };
 
             this.next = function(draft) {

--- a/src/wizardForm.js
+++ b/src/wizardForm.js
@@ -1,0 +1,11 @@
+angular.module('mgo-angular-wizard').directive('wzForm', function () {
+    return {
+        restrict: 'A',
+        require: ['^wzStep', '^form'],
+        link: function ($scope, $element, $attris, controllers) {
+            var step = controllers && controllers.length > 0 ? controllers[0] : undefined;
+            var form = controllers && controllers.length > 1 ? controllers[1] : undefined;
+            if (step && form) step.addForm(form);
+        }
+    };
+});


### PR DESCRIPTION
Fix  : disable uncompleted step change issue in IE8
Add: step's **displayTitle**. you can set i18n title in here.
Add: **wzForm**, now you can add the wz-form to the inner form in step.and if the form is invalid, function 'goto' or 'next' will be break.  wzForm's target form will has attribute call **submitted**, it will be 'true' when function 'next' or 'goto' raise.


	<wizard on-finish="finishedWizard()"> 
		<wz-step title="Starting">
			<form wz-form name="step1Form">
				 <div class="form-group" ng-class="{'has-error' : (step1Form.$invalid && step1Form.submitted)}">
					<input type="email" required="" />
				</div>
			</form>
			<input type="submit" wz-next value="Continue" />
		</wz-step>
	</wizard>