### PR TITLE
prefixes variables and makes them overridable

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,13 @@ The navigation bar shown below works in the following way:
 * Editing step (Modifying a step already completed in the past) is painted as red
 * You can click in any completed step to go back to that step. You can't click in the current step nor in the future ones unless you've already completed a future step before (for example in EditMode all steps are completed by default)
 
-All of those colors are variables in the `angular-wizard.less`. You can easily change them by changing the colors in that file
+### Color Definitions
+All of those colors are variables in the `angular-wizard.less`. You can easily change them by importing the `angular-wizard.less` file into your own less file(s) and change the variables.
+The available variables are:
+* @wz-color-default
+* @wz-color-done
+* @wz-color-current
+* @wz-color-editing
 
 # Contributors
 

--- a/src/angular-wizard.less
+++ b/src/angular-wizard.less
@@ -1,10 +1,11 @@
+@wz-color-default: #E6E6E6;
+@wz-color-current: #808080;
+@wz-color-done:    #339933;
+@wz-color-editing: #FF0000;
+
 .steps-indicator {
   /* ---- steps quantity ---- */
 
-  @color-default: #E6E6E6;
-  @color-current: #808080;
-  @color-done:    #339933;
-  @color-editing: #FF0000;
 
   position: absolute;
   right: 0;
@@ -18,7 +19,7 @@
 
 
   &:before {
-    background-color: @color-default;
+    background-color: @wz-color-default;
     content: '';
     position: absolute;
     height: 1px;
@@ -87,7 +88,7 @@
     line-height: 15px;
 
     a {
-      color: @color-current;
+      color: @wz-color-current;
       text-decoration: none;
       text-transform: uppercase;
       font-weight: bold;
@@ -101,13 +102,13 @@
         width: 14px;
         height: 14px;
         border-radius: 100%;
-        background-color: @color-default;
+        background-color: @wz-color-default;
         content: '';
         transition: 0.25s;
       }
 
       &:hover {
-        color: darken(@color-current, 20%);
+        color: darken(@wz-color-current, 20%);
       }
     }
   }
@@ -156,7 +157,7 @@
     pointer-events: none;
 
     a:hover {
-      color: @color-current;
+      color: @wz-color-current;
     }
   }
 
@@ -166,14 +167,14 @@
   }
 
   li.current a:before {
-    background-color: @color-current;
+    background-color: @wz-color-current;
   }
 
   li.done a:before {
-    background-color: @color-done;
+    background-color: @wz-color-done;
   }
 
   li.editing a:before {
-    background-color: @color-editing;
+    background-color: @wz-color-editing;
   }
 }


### PR DESCRIPTION
The current implementation of the less stylesheets makes it impossible to override the variables from the users own less file because the variables are scoped.
You had to manually copy the code in the less file and change the variables there.
This PR moves the variables out of the scope and prefixes them so they don't interfere with other variables that may exist in the user's code.

you now can do the following to override the colors:

```less
//my-own-styling.less
@import "path/to/dist/angular-wizard"; //import the file

@wz-color-default: #EEE; //override the variables
@wz-color-done: #0000FF;
```