### PR TITLE
add css to bower's main object

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "angular-wizard",
   "version": "0.4.2",
-  "main": "./dist/angular-wizard.js",
+  "main": ["./dist/angular-wizard.js", "./dist/angular-wizard.css"],
   "description": "Easy to use Wizard library for AngularJS",
   "repository": {
     "type": "git",


### PR DESCRIPTION
wiredep uses bower's info to inject css and js so we need to have both files declared