### PR TITLE
Add sass files as an option

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -19,7 +19,7 @@ module.exports = function(grunt) {
     dirs: {
       dest: 'dist'
     },
-    clean: [ 
+    clean: [
       '<%= dirs.dest %>'
     ],
     concat: {
@@ -78,14 +78,25 @@ module.exports = function(grunt) {
     copy: {
       less_files: {
         files: [
-          { 
+          {
             src: [ 'src/angular-wizard.less' ],
             dest: '<%= dirs.dest %>',
             cwd: '.',
             expand: true,
             flatten: true
           }
-       ]   
+       ]
+      },
+      sass_files: {
+        files: [
+          {
+            src: [ 'src/angular-wizard.scss' ],
+            dest: '<%= dirs.dest %>',
+            cwd: '.',
+            expand: true,
+            flatten: true
+          }
+        ]
       }
     },
     bowerInstall: {
@@ -163,17 +174,17 @@ module.exports = function(grunt) {
   // Build task.
   grunt.registerTask('build', [
     'clean',
-    'bowerInstall', 
+    'bowerInstall',
     'copy',
     'less',
     'cssmin',
     'html2js',
-    'concat', 
-    'uglify', 
+    'concat',
+    'uglify',
     'karma:build']);
 
   grunt.registerTask('test', ['build']);
-  
+
   grunt.registerTask('travis', ['build']);
 
   // Provides the "bump" task.

--- a/dist/angular-wizard.less
+++ b/dist/angular-wizard.less
@@ -1,10 +1,11 @@
+@wz-color-default: #E6E6E6;
+@wz-color-current: #808080;
+@wz-color-done:    #339933;
+@wz-color-editing: #FF0000;
+
 .steps-indicator {
   /* ---- steps quantity ---- */
 
-  @color-default: #E6E6E6;
-  @color-current: #808080;
-  @color-done:    #339933;
-  @color-editing: #FF0000;
 
   right: 0;
   bottom: 0;
@@ -17,7 +18,7 @@
 
 
   &:before {
-    background-color: @color-default;
+    background-color: @wz-color-default;
     content: '';
     position: absolute;
     height: 1px;
@@ -86,7 +87,7 @@
     line-height: 15px;
 
     a {
-      color: @color-current;
+      color: @wz-color-current;
       text-decoration: none;
       text-transform: uppercase;
       font-weight: bold;
@@ -100,13 +101,13 @@
         width: 14px;
         height: 14px;
         border-radius: 100%;
-        background-color: @color-default;
+        background-color: @wz-color-default;
         content: '';
         transition: 0.25s;
       }
 
       &:hover {
-        color: darken(@color-current, 20%);
+        color: darken(@wz-color-current, 20%);
       }
     }
   }
@@ -155,7 +156,7 @@
     pointer-events: none;
 
     a:hover {
-      color: @color-current;
+      color: @wz-color-current;
     }
   }
 
@@ -165,14 +166,14 @@
   }
 
   li.current a:before {
-    background-color: @color-current;
+    background-color: @wz-color-current;
   }
 
   li.done a:before {
-    background-color: @color-done;
+    background-color: @wz-color-done;
   }
 
   li.editing a:before {
-    background-color: @color-editing;
+    background-color: @wz-color-editing;
   }
 }

--- a/dist/angular-wizard.scss
+++ b/dist/angular-wizard.scss
@@ -1,0 +1,107 @@
+.steps-indicator {
+  /* ---- steps quantity ---- */
+
+  $color-default: #E6E6E6;
+  $color-current: #337AB7;
+  $color-done:    #339933;
+  $color-editing: #FF0000;
+
+  $max-number-of-steps: 10;
+
+  right: 0;
+  bottom: 0;
+  left: 0;
+  margin: 0;
+  padding: 20px 0 0 0;
+  height: 30px;
+  list-style: none;
+
+
+
+  &:before {
+    background-color: $color-default;
+    content: '';
+    position: absolute;
+    height: 1px;
+  }
+
+  @for $i from 2 through $max-number-of-steps {
+    &.steps-#{$i}:before {
+      left: unquote('calc(100% / '+ #{$i} +' / 2)');
+    }
+  }
+
+  /* --- http://www.paulirish.com/2012/box-sizing-border-box-ftw/ ---- */
+  * {
+    -webkit-box-sizing: border-box;
+    -moz-box-sizing: border-box;
+    box-sizing: border-box;
+  }
+
+
+  li {
+    position: relative;
+    float: left;
+    margin: 0;
+    padding: 0;
+    padding-top: 10px;
+    text-align: center;
+    line-height: 15px;
+
+    a {
+      color: $color-current;
+      text-decoration: none;
+      text-transform: uppercase;
+      font-weight: bold;
+      transition: 0.25s;
+      cursor: pointer;
+
+      &:before {
+        position: absolute;
+        top: -7px;
+        left: unquote('calc(50% - 7px)');
+        width: 14px;
+        height: 14px;
+        border-radius: 100%;
+        background-color: $color-default;
+        content: '';
+        transition: 0.25s;
+      }
+
+      &:hover {
+        color: darken($color-current, 20%);
+      }
+    }
+  }
+
+  @for $i from 2 through $max-number-of-steps+1 {
+    &.steps-#{$i} {
+      left: unquote('calc(100% / '+ #{$i} +')');
+    }
+  }
+
+  li.default {
+    pointer-events: none;
+
+    a:hover {
+      color: $color-current;
+    }
+  }
+
+  li.current,
+  li.editing {
+    pointer-events: none;
+  }
+
+  li.current a:before {
+    background-color: $color-current;
+  }
+
+  li.done a:before {
+    background-color: $color-done;
+  }
+
+  li.editing a:before {
+    background-color: $color-editing;
+  }
+}

--- a/src/angular-wizard.scss
+++ b/src/angular-wizard.scss
@@ -1,0 +1,108 @@
+$wz-color-default: #E6E6E6;
+$wz-color-current: #337AB7;
+$wz-color-done:    #339933;
+$wz-color-editing: #FF0000;
+
+$wz-max-number-of-steps: 10;
+
+.steps-indicator {
+  /* ---- steps quantity ---- */
+
+
+  right: 0;
+  bottom: 0;
+  left: 0;
+  margin: 0;
+  padding: 20px 0 0 0;
+  height: 30px;
+  list-style: none;
+
+
+
+  &:before {
+    background-color: $wz-color-default;
+    content: '';
+    position: absolute;
+    height: 1px;
+  }
+
+  @for $i from 2 through $wz-max-number-of-steps {
+    &.steps-#{$i}:before {
+      left: unquote('calc(100% / '+ #{$i} +' / 2)');
+    }
+  }
+
+  /* --- http://www.paulirish.com/2012/box-sizing-border-box-ftw/ ---- */
+  * {
+    -webkit-box-sizing: border-box;
+    -moz-box-sizing: border-box;
+    box-sizing: border-box;
+  }
+
+
+  li {
+    position: relative;
+    float: left;
+    margin: 0;
+    padding: 0;
+    padding-top: 10px;
+    text-align: center;
+    line-height: 15px;
+
+    a {
+      color: $wz-color-current;
+      text-decoration: none;
+      text-transform: uppercase;
+      font-weight: bold;
+      transition: 0.25s;
+      cursor: pointer;
+
+      &:before {
+        position: absolute;
+        top: -7px;
+        left: unquote('calc(50% - 7px)');
+        width: 14px;
+        height: 14px;
+        border-radius: 100%;
+        background-color: $wz-color-default;
+        content: '';
+        transition: 0.25s;
+      }
+
+      &:hover {
+        color: darken($wz-color-current, 20%);
+      }
+    }
+  }
+
+  @for $i from 2 through $wz-max-number-of-steps+1 {
+    &.steps-#{$i} {
+      left: unquote('calc(100% / '+ #{$i} +')');
+    }
+  }
+
+  li.default {
+    pointer-events: none;
+
+    a:hover {
+      color: $wz-color-current;
+    }
+  }
+
+  li.current,
+  li.editing {
+    pointer-events: none;
+  }
+
+  li.current a:before {
+    background-color: $wz-color-current;
+  }
+
+  li.done a:before {
+    background-color: $wz-color-done;
+  }
+
+  li.editing a:before {
+    background-color: $wz-color-editing;
+  }
+}


### PR DESCRIPTION
Add sass files as an option to use a css processor.

I think that angular-wizard should provide both options (as I'm using the sass processor in my project and I won't add less just to make some changes in the angular-wizard's css).

The angular-wizard.css is still generated from .less, the .scss file is just copied to dist folder.