### PR TITLE
Add ability to specify an order for each step

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ Let's go step by step to see how this works.
 * **wz-disabled**
 * **description:** A description available to use in each step's UI.
 * **wz-data** Data you wish to make available to the steps scope.
+* **wz-order** The order in which the steps should be in. If no order or duplicated order it will add the step to the end.
 
 3) Inside the step, we now see a button which has a `wz-next` attribute. That means that clicking that button will send the user to the next step of wizard. Similar to `wz-next`, we have the following attributes:
 * **wz-previous**: Goes to the previous step

--- a/src/step.js
+++ b/src/step.js
@@ -9,7 +9,8 @@ angular.module('mgo-angular-wizard').directive('wzStep', function() {
             canexit : '=',
             disabled: '@?wzDisabled',
             description: '@',
-            wzData: '='
+            wzData: '=',
+            wzOrder: '@?'
         },
         require: '^wizard',
         templateUrl: function(element, attributes) {

--- a/src/wizard.js
+++ b/src/wizard.js
@@ -93,22 +93,24 @@ angular.module('mgo-angular-wizard').directive('wizard', function() {
 
             //called each time step directive is loaded
             this.addStep = function(step) {
-                //pushing the scope of directive onto step array
-                $scope.steps.push(step);
-                //if this is first step being pushed then goTo that first step
-                if ($scope.getEnabledSteps().length === 1) {
+                var wzOrder = (step.wzOrder >= 0 && !$scope.steps[step.wzOrder]) ? step.wzOrder : $scope.steps.length,
+                    currentFirstStepIdx = stepIdx($scope.getEnabledSteps()[0]);
+                //adding the scope of directive onto step array
+                $scope.steps[wzOrder] = step;
+                //if this step is the new first then goTo it
+                if (wzOrder === 0 || stepIdx(step) < currentFirstStepIdx) {
                     //goTo first step
                     $scope.goTo($scope.getEnabledSteps()[0]);
                 }
             };
             
-            //called each time step diretive is destroyed
+            //called each time step directive is destroyed
             this.removeStep = function (step) {
                 var index = $scope.steps.indexOf(step);
                 if (index > 0) {
                     $scope.steps.splice(index, 1);
                 }
-            }
+            };
 
             this.context = $scope.context;
 
@@ -218,7 +220,7 @@ angular.module('mgo-angular-wizard').directive('wizard', function() {
 
             $scope.getEnabledSteps = function() {
                 return $scope.steps.filter(function(step){
-                    return step.disabled !== 'true';
+                    return step && step.disabled !== 'true';
                 });
             };
 
@@ -248,7 +250,7 @@ angular.module('mgo-angular-wizard').directive('wizard', function() {
 
             this.totalStepCount = function() {
                 return $scope.getEnabledSteps().length;
-            }
+            };
 
             //Access to enabled steps from outside
             this.getEnabledSteps = function(){

--- a/src/wizard.js
+++ b/src/wizard.js
@@ -93,12 +93,11 @@ angular.module('mgo-angular-wizard').directive('wizard', function() {
 
             //called each time step directive is loaded
             this.addStep = function(step) {
-                var wzOrder = (step.wzOrder >= 0 && !$scope.steps[step.wzOrder]) ? step.wzOrder : $scope.steps.length,
-                    currentFirstStepIdx = stepIdx($scope.getEnabledSteps()[0]);
+                var wzOrder = (step.wzOrder >= 0 && !$scope.steps[step.wzOrder]) ? step.wzOrder : $scope.steps.length;
                 //adding the scope of directive onto step array
                 $scope.steps[wzOrder] = step;
                 //if this step is the new first then goTo it
-                if (wzOrder === 0 || stepIdx(step) < currentFirstStepIdx) {
+                if ($scope.getEnabledSteps()[0] === step) {
                     //goTo first step
                     $scope.goTo($scope.getEnabledSteps()[0]);
                 }

--- a/test/angularWizardSpec.js
+++ b/test/angularWizardSpec.js
@@ -311,5 +311,39 @@ describe( 'AngularWizard', function() {
         view.isolateScope().steps = ["5", "6", "7"];
         view.isolateScope().$digest();
         expect(WizardHandler.wizard().getEnabledSteps().length).toBe(3);
-    });    
+    });
+    it("should add steps based on order", function () {
+        var scope = $rootScope.$new();
+        scope.steps = [{title: "One", order: 1}, {title: "Zero", order: 0}];
+        var element = angular.element('<wizard><wz-step ng-repeat="step in steps" wz-title="{{step.title}}" wz-order="{{step.order}}">{{step.title}}</wz-step></wizard>');
+        var view = $compile(element)(scope);
+        $rootScope.$digest();
+        expect(WizardHandler.wizard().totalStepCount()).toBe(2);
+        expect(view.isolateScope().steps[0].wzTitle).toEqual(scope.steps[1].title);
+    });
+    it("should append step to end if step at order exists", function () {
+        var scope = $rootScope.$new();
+        scope.steps = [{title: "One", order: 1}, {title: "Zero", order: 0}];
+        var element = angular.element('<wizard><wz-step ng-repeat="step in steps" wz-title="{{step.title}}" wz-order="{{step.order}}">{{step.title}}</wz-step></wizard>');
+        var view = $compile(element)(scope);
+        $rootScope.$digest();
+        var newStep = $rootScope.$new();
+        newStep.wzTitle = 'New Step';
+        newStep.wzOrder = 0;
+        WizardHandler.wizard().addStep(newStep);
+        $rootScope.$digest();
+        expect(WizardHandler.wizard().totalStepCount()).toBe(3);
+        expect(view.isolateScope().steps[2].wzTitle).toEqual(newStep.wzTitle);
+    });
+    it("should always append to end if no order defined", function () {
+        var scope = $rootScope.$new();
+        scope.steps = [{title: "One"}, {title: "Zero"}, {title: "Two"}];
+        var element = angular.element('<wizard><wz-step ng-repeat="step in steps" wz-title="{{step.title}}">{{step.title}}</wz-step></wizard>');
+        var view = $compile(element)(scope);
+        $rootScope.$digest();
+        expect(WizardHandler.wizard().totalStepCount()).toBe(3);
+        scope.steps.forEach(function (step, index) {
+            expect(view.isolateScope().steps[index].wzTitle).toEqual(step.title);
+        });
+    });
 });


### PR DESCRIPTION
The idea here is to allow ordering the steps with minimal amount of code. This give a level of flexibility currently not available. In its current form there is room for improvement like inserting a step in the middle of already existing steps. At current if there is a step already defined and the given position or no order is defined it will simply add it to the end of the steps array.