### PR TITLE
Fix JS Error of issue #273

### DIFF
--- a/dist/angular-wizard.js
+++ b/dist/angular-wizard.js
@@ -233,7 +233,7 @@ angular.module('mgo-angular-wizard').directive('wizard', function() {
                             $scope.$emit('wizard:stepChanged', {step: step, index: stepIdx(step)});
                             //$log.log('current step number: ', $scope.currentStepNumber());
                         } else {
-                            $scope.$emit('wizard:stepChangeFailed', {step: step, index: _.indexOf($scope.getEnabledSteps(), step)});
+                            $scope.$emit('wizard:stepChangeFailed', {step: step, index: $scope.getEnabledSteps().indexOf(step)});
                         }
                     });
                 }


### PR DESCRIPTION
By calling indexOf directly on the array the JS error of issue #273 could be prevented.

PS: Not sure if the white spaces where set correctly, but the only change that I made was in line 236 `_.indexOf($scope.getEnabledSteps(), step)` -> `$scope.getEnabledSteps().indexOf(step)`.