### PR TITLE
Fixed error in sample code

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ Angular Wizard emits the following events on the `scope` and pass an object with
 ````javascript
 $scope.$on('wizard:stepChanged',function(event, args) {
     console.log(args);
-}
+});
 ````
 
 ## Navigation bar


### PR DESCRIPTION
A closing paren was missing in one of the examples.